### PR TITLE
Use "text-overflow:ellipsis" to prevent overflow in header

### DIFF
--- a/css/lists.css
+++ b/css/lists.css
@@ -28,6 +28,8 @@
   font-weight: normal;
   color: #ff4E00;
   text-transform: uppercase;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* List items */


### PR DESCRIPTION
If you open a folder with a really long name, then the folder-name displayed in the header will overflow off the screen, and make the app wider from the screen. (which makes it "pannable" in a way that looks broken).

Patch attached to fix this, by giving this header "text-overflow: ellipsis" (and overflow:hidden, which is required for "text-overflow" to work).
